### PR TITLE
Prevent creating locks for empty batches

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,9 @@ MemoryStore.prototype.takeFirstN = function (n, cb) {
     tasks[taskId] = self._tasks[taskId];
     delete self._tasks[taskId];
   })
-  self._running[lockId] = tasks;
+  if (taskIds.length > 0) {
+    self._running[lockId] = tasks;
+  }
   cb(null, lockId);
 }
 
@@ -78,7 +80,9 @@ MemoryStore.prototype.takeLastN = function (n, cb) {
     tasks[taskId] = self._tasks[taskId];
     delete self._tasks[taskId];
   })
-  self._running[lockId] = tasks;
+  if (taskIds.length > 0) {
+    self._running[lockId] = tasks;
+  }
   cb(null, lockId);
 }
 


### PR DESCRIPTION
Fixes #1 

This PR changes the `takeFirstN` and `takeLastN` functions to only store a lock if there are items in the returned batch. This prevents empty batches from being taken and subsequently the locks never being released for them.